### PR TITLE
Add `--no-overwrite-dir` on tar extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes from the Luizalabs team to this project will be documented in this file.
 
+## [NEXT_RELEASE]
+### Changed
+- Use `--no-overwrite-dir` flag on tar extraction
+
 ## [3.0.1] - 2018-03-05
 ### Fixed
 - Don't remove the pre-downloaded slug.tgz

--- a/rootfs/runner/init
+++ b/rootfs/runner/init
@@ -11,15 +11,15 @@ mkdir -p $HOME
 if [[ $(ls -A $HOME) ]]; then
 	true
 elif [[ -f "$SLUG_DIR/slug.tgz" ]]; then
-	tar -xzf "$SLUG_DIR/slug.tgz" -C $HOME
+	tar -xzf "$SLUG_DIR/slug.tgz" -C $HOME --no-overwrite-dir
 	unset SLUG_URL
 elif [[ $SLUG_URL ]]; then
 	get_object
-	tar -xzf slug.tgz -C $HOME
+	tar -xzf slug.tgz -C $HOME --no-overwrite-dir
 	rm slug.tgz
 	unset SLUG_URL
 else
-	cat | tar -xzC $HOME
+	cat | tar -xzC $HOME --no-overwrite-dir
 fi
 
 cd $HOME


### PR DESCRIPTION
This change preserves metadata of $HOME dir (/app)
when a volume is mounted on this dir (useful to share fs with app container and sidecars)

Also solve tar extraction issues with dir permissions like:
```
tar: .: Cannot utime: Operation not permitted
tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted
tar: Exiting with failure status due to previous errors
```